### PR TITLE
Update to latest nightly rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,15 @@
 [package]
-
 name = "voxlap"
 version = "0.0.1"
 authors = ["bbodi <bodidev@gmail.com>"]
+description = ""
+license = "MIT"
+
+[dependencies]
+c_vec = "^1.3"
+libc = "^0.2"
+num = "^0.3"
+rand = "^0.7"
+
+[lib]
+name = "voxlap"

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -9,6 +9,7 @@ pub struct lpoint3d {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct point3d {
     pub x: c_float,
     pub y: c_float,
@@ -81,12 +82,12 @@ impl vx5sprite {
 #[repr(C)]
 pub struct hingetype {
     parent: c_long,
-    p: [point3d, ..2],
-    v: [point3d, ..2],
+    p: [point3d; 2],
+    v: [point3d; 2],
     vmin: c_short,
     vmax: c_short,
     htype: c_char,
-    filler: [c_char, ..7]
+    filler: [c_char; 7]
 }
 
 #[repr(C)]


### PR DESCRIPTION
Hi, I faced with a lot of difficulties when tried to compile the library with recent rust compiler. The PR contains my first operational build, ported example is located at https://github.com/NCrashed/rust-voxlap-test

Major changes refer to:
* std library
* namespaces for enums
* array syntax 
* operators overloading 
* range iterator syntx 
* unsafe coercing
* `from_cvec` now `from_bytes` as latest SDL2 provides `&mut [u8]` instead of cvec.

